### PR TITLE
Temporarily removed mobile menu button from navbar

### DIFF
--- a/src/backend/templates/responseMap.html
+++ b/src/backend/templates/responseMap.html
@@ -27,18 +27,6 @@
       <a class="navbar-brand ms-2" href="/">
         <span><i class="icon icon-arrow-left"></i></span>
       </a>
-
-      <button
-        class="navbar-toggler me-2"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarNav"
-        aria-controls="navbarNav"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
     </nav>
     <div
       id="map"


### PR DESCRIPTION
### Problem
- The navigation bar includes a menu button (navbar-toggler) that appears only on mobile screens.
- Currently, the system does not have enough menu items to justify the presence of a collapsible menu.
- Keeping the button might create confusion for users, as it serves no functional purpose at the moment.

### Solution
- Removed the mobile menu button code from `responseMap.html`.

### How To Test
1. Run the application and open it on both desktop and mobile views.
2. Verify that the navigation bar is displayed correctly.
3. Confirm that the menu button (navbar-toggler) is no longer present on mobile screens.
4. Ensure that the removal does not break any other elements in the navigation bar.

### Fixes 
- #11 
