### PR TITLE
13 ensure only one infowindow is open at a time when clicking on markers

### DIFF
--- a/src/backend/controllers/tripController.js
+++ b/src/backend/controllers/tripController.js
@@ -34,7 +34,7 @@ class TripController {
 
 const generateHTML = (trip) => {
   if (!trip) {
-    throw new Error('Trip not informed');
+    throw new Error('Trip data is required to generate HTML');
   }
 
   let template = loadTemplateFile();

--- a/src/backend/service/prompt.js
+++ b/src/backend/service/prompt.js
@@ -8,7 +8,7 @@ const createPrompt = (destination, days, categories) => `
       - Name of the place.
       - A brief description.
       - Estimated entrance fee (if applicable; otherwise, specify "Free").
-      - Opening hours.
+      - Opening hours (if it's always open, specify "Open 24 hours").
       - Estimated visit duration.
       - Geolocation (latitude, longitude).
   Respond with JSON only, formatted as follows:

--- a/src/backend/templates/responseMap.html
+++ b/src/backend/templates/responseMap.html
@@ -35,10 +35,16 @@
     ></div>
     <script>
       async function initMap(trip) {
+        if (!trip || !trip.geolocation || !trip.days) {
+          console.error('Invalid trip data provided.');
+          return;
+        }
+
         const position = {
           lat: trip.geolocation.lat,
           lng: trip.geolocation.lng,
         };
+
         const options = {
           zoom: 13,
           center: position,
@@ -56,14 +62,32 @@
           options
         );
 
+        const infoWindow = new google.maps.InfoWindow();
+
+        function addMarker({ title, content, coord }) {
+          const marker = new google.maps.marker.AdvancedMarkerElement({
+            map,
+            title,
+            position: coord,
+          });
+
+          marker.addListener('gmp-click', function () {
+            infoWindow.setContent(content);
+            infoWindow.open(map, marker);
+          });
+        }
+
         trip.days.forEach((day) => {
-          day.tourist_attractions.forEach((attraction) => {
+          day.tourist_attractions?.forEach((attraction) => {
+            if (!attraction.geolocation) return; // Ensure geolocation exists
+
             const content = `
-              <h6>${attraction.name}</h6>
-              <p>${attraction.description}</p>
-              <p><strong>Opening hours:</strong> ${attraction.opening_hours}
-              <br>
-              <strong>Entrance:</strong> ${attraction.entrance_fee}</p>
+              <div>
+                <h6>${attraction.name}</h6>
+                <p>${attraction.description}</p>
+                <p><strong>Opening hours:</strong> ${attraction.opening_hours}<br>
+                <strong>Entrance:</strong> ${attraction.entrance_fee || 'Free'}</p>
+              </div>
             `;
 
             addMarker({
@@ -77,24 +101,8 @@
           });
         });
 
-        function addMarker(props) {
-          const marker = new google.maps.marker.AdvancedMarkerElement({
-            map: map,
-            position: props.coord,
-            title: props.title,
-          });
-
-          if (props.content) {
-            const infoWindow = new google.maps.InfoWindow({
-              content: props.content,
-              maxWidth: 270,
-            });
-
-            marker.addListener('gmp-click', function () {
-              infoWindow.open(map, marker);
-            });
-          }
-        }
+        // Close InfoWindow when clicking anywhere on the map
+        map.addListener('click', () => infoWindow.close());
       }
       initMap(_trip);
     </script>


### PR DESCRIPTION
### Problem
- Currently, when clicking on multiple markers on the map, multiple InfoWindows remain open simultaneously, leading to a cluttered and confusing UI. This behavior impacts the user experience as multiple pieces of information are visible at once, making the interface harder to navigate.

### Solution
- The solution ensures that only one InfoWindow is open at a time by creating a single instance of InfoWindow and dynamically updating its content when a marker is clicked. If an InfoWindow is already open, it will be closed before opening a new one. Additionally, a listener is added to the map so that clicking anywhere outside of a marker will close the open InfoWindow. This keeps the interface clean and user-friendly.

### How To Test
1. Ensure that the map has multiple markers.
2. Click on a marker. The corresponding InfoWindow should open, displaying the relevant information.
3. Click on another marker. The previously opened InfoWindow should close, and the new one should open with the updated content.
4. Click anywhere on the map outside of a marker. The open InfoWindow should close.
5. Test the functionality across different screen sizes and map interactions (zoom, pan) to confirm the behavior is consistent.

### Fixes 
- #13 
