### PR TITLE
Add Placeholder Image for Missing Google Maps Place Photos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-trip-planner",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A travel planning assistant powered by ChatGPT, helping users create personalized itineraries and trip recommendations.",
   "main": "server.js",
   "scripts": {

--- a/src/backend/templates/responseMap.html
+++ b/src/backend/templates/responseMap.html
@@ -81,7 +81,7 @@
           day.tourist_attractions?.forEach(async (attraction) => {
             if (!attraction.geolocation) return; // Ensure geolocation exists
 
-            const photoUrl = await getPlacePhotoUrl(attraction.name, map);
+            const photoUrl = await getPhotoUrl(attraction.name, map);
 
             const content = `
               <div>
@@ -109,6 +109,11 @@
 
         // Close InfoWindow when clicking anywhere on the map
         map.addListener('click', () => infoWindow.close());
+      }
+      
+      async function getPhotoUrl(placeName, map) {
+        const photoUrl = await getPlacePhotoUrl(placeName, map);
+        return photoUrl || 'https://placehold.co/600x400?text=...';
       }
 
       async function getPlacePhotoUrl(placeName, map) {


### PR DESCRIPTION
### Problem
- When fetching a place image from the Google Maps API, some locations do not have available photos, resulting in an empty or broken image display. This negatively impacts the user experience.

### Solution
- Implemented a fallback mechanism to display a placeholder image (`https://placehold.co/600x400?text=...`) whenever a place image cannot be retrieved from the API.
- Updated the function responsible for fetching place images to return the placeholder URL when no photos are found.

### How To Test
- Search for a place with an available image and verify that the correct image is displayed.
- Search for a place that does not have an image and confirm that the placeholder image appears instead.
- Ensure the implementation works across different browsers and screen sizes.

### Fixes 
- #17 