### PR TITLE
Activate StreetViewControl

### DIFF
--- a/src/backend/templates/responseMap.html
+++ b/src/backend/templates/responseMap.html
@@ -83,7 +83,7 @@
           gestureHandling: 'auto',
           scrollwheel: true,
           mapTypeControl: false,
-          streetViewControl: false,
+          streetViewControl: true,
           fullscreenControl: false,
         };
 


### PR DESCRIPTION
### Problem
- The Street View control was not enabled in the Google Maps configuration, preventing users from accessing the 360-degree street-level imagery.
- This limited the interactive navigation experience within the map.

### Solution
- Updated the Google Maps options object to include `streetViewControl: true`.
- Ensured that the Pegman icon appears on the map, allowing users to activate Street View.
- Verified that other map controls (zoom, gesture handling, scrollwheel) continue to function as expected.

### How To Test
1. Open the application where Google Maps is integrated.
2. Confirm that the Street View (Pegman) icon is visible on the map.
3. Drag the Pegman icon onto a supported street and verify that Street View opens correctly.
4. Ensure that other controls (zoom, scrolling, gestures) still work properly.
5. Test on different browsers (Chrome, Firefox, Edge, Safari) and on mobile devices to ensure consistent behavior.

### Fixes 
- #23 
