### PR TITLE
Included destination name in Google Maps api photo search

### DIFF
--- a/src/backend/templates/responseMap.html
+++ b/src/backend/templates/responseMap.html
@@ -111,7 +111,9 @@
           day.tourist_attractions?.forEach(async (attraction) => {
             if (!attraction.geolocation) return; // Ensure geolocation exists
 
-            const photoUrl = await getPhotoUrl(attraction.name, map);
+            const placeName = attraction.name;
+            const destination = trip.destination;
+            const photoUrl = await getPhotoUrl(placeName, destination, map);
 
             const content = `
               <div>
@@ -141,19 +143,19 @@
         map.addListener('click', () => infoWindow.close());
       }
       
-      async function getPhotoUrl(placeName, map) {
-        const photoUrl = await getPlacePhotoUrl(placeName, map);
+      async function getPhotoUrl(placeName, destination, map) {
+        const photoUrl = await getPlacePhotoUrl(placeName, destination, map);
         return photoUrl || 'https://placehold.co/600x400?text=...';
       }
 
-      async function getPlacePhotoUrl(placeName, map) {
+      async function getPlacePhotoUrl(placeName, destination, map) {
         return new Promise((resolve, reject) => {
           const service = new google.maps.places.PlacesService(map);
 
           // Search Place ID by the local name.
           service.findPlaceFromQuery(
             {
-              query: placeName, 
+              query: placeName + ' ' + destination, 
               fields: ['place_id']
             },
             (results, status) => {


### PR DESCRIPTION
### Problem
- The search for place photos using Google Maps API only includes the place name (placeName).
- This can lead to ambiguous results when multiple locations share the same name in different destinations.
- Users may see photos from the wrong location, causing confusion.

### Solution
- Updated the `query` parameter in `findPlaceFromQuery` to include both `placeName` and `destination`.
- This makes the search more specific, reducing the chances of retrieving photos from unrelated places.
- Ensured that this update is applied across all photo-related searches.

### How To Test
1. Run the application and enter a destination and a place name (e.g., "Central Park" in "New York").
2. Verify that the returned photos match the correct location.
3. Repeat the test with a place that exists in multiple cities (e.g., "Plaza Mayor" in "Madrid" and "Lima").
4. Confirm that the query now retrieves photos for the correct destination.
5. Check that no existing functionalities related to place searches are broken.

### Fixes 
- #25 